### PR TITLE
fix: alsa

### DIFF
--- a/cpu01-edgefarm-image/kasfile.yaml
+++ b/cpu01-edgefarm-image/kasfile.yaml
@@ -19,4 +19,3 @@ local_conf_header:
   src/meta-custom: |
     #Prefix to the resulting deployable tarball name
     BASENAME = "EdgeFarm-Image"
-    BBMASK += "/meta-toradex-nxp/recipes-bsp/alsa-state"

--- a/cpu01-edgefarm-image/kasfile.yaml
+++ b/cpu01-edgefarm-image/kasfile.yaml
@@ -19,3 +19,4 @@ local_conf_header:
   src/meta-custom: |
     #Prefix to the resulting deployable tarball name
     BASENAME = "EdgeFarm-Image"
+    BBMASK += "/meta-toradex-nxp/recipes-bsp/alsa-state"

--- a/kas-includes/kasfile-tdxbsp.yaml
+++ b/kas-includes/kasfile-tdxbsp.yaml
@@ -69,3 +69,5 @@ local_conf_header:
     INHERIT += "toradex-mirrors"
     DISTRO = "tdx-xwayland"
     ACCEPT_FSL_EULA = "1"
+    # Exclude toradex alsa-state bbappend from build
+    BBMASK += "/meta-toradex-nxp/recipes-bsp/alsa-state"

--- a/kas-includes/kasfile-tdxbsp.yaml
+++ b/kas-includes/kasfile-tdxbsp.yaml
@@ -4,7 +4,7 @@ repos:
   # ci4rail
   src/meta-ci4rail-bsp:
     url: https://github.com/ci4rail/meta-ci4rail-bsp.git
-    refspec: a13bdc809c05f8828606def330900cd116cc8d6d
+    refspec: 2759d64824ab493434eb6a1d6860b7cb0cc46d91
 
   # from tdx: https://git.toradex.com/cgit/toradex-manifest.git/tree/bsp/pinned-nxp.xml?h=5.7.0
   src/meta-freescale-3rdparty.git:

--- a/kas-includes/kasfile-tdxbsp.yaml
+++ b/kas-includes/kasfile-tdxbsp.yaml
@@ -4,7 +4,7 @@ repos:
   # ci4rail
   src/meta-ci4rail-bsp:
     url: https://github.com/ci4rail/meta-ci4rail-bsp.git
-    refspec: 26100f41f1baf0cfbf0f96ca28672633de27b05e
+    refspec: d7947a05a8e3d592ff5b7ea88e6bd363ac04da14
 
   # from tdx: https://git.toradex.com/cgit/toradex-manifest.git/tree/bsp/pinned-nxp.xml?h=5.7.0
   src/meta-freescale-3rdparty.git:

--- a/kas-includes/kasfile-tdxbsp.yaml
+++ b/kas-includes/kasfile-tdxbsp.yaml
@@ -4,7 +4,7 @@ repos:
   # ci4rail
   src/meta-ci4rail-bsp:
     url: https://github.com/ci4rail/meta-ci4rail-bsp.git
-    refspec: 2759d64824ab493434eb6a1d6860b7cb0cc46d91
+    refspec: 26100f41f1baf0cfbf0f96ca28672633de27b05e
 
   # from tdx: https://git.toradex.com/cgit/toradex-manifest.git/tree/bsp/pinned-nxp.xml?h=5.7.0
   src/meta-freescale-3rdparty.git:

--- a/kas-includes/kasfile-tdxbsp.yaml
+++ b/kas-includes/kasfile-tdxbsp.yaml
@@ -4,7 +4,7 @@ repos:
   # ci4rail
   src/meta-ci4rail-bsp:
     url: https://github.com/ci4rail/meta-ci4rail-bsp.git
-    refspec: d7947a05a8e3d592ff5b7ea88e6bd363ac04da14
+    refspec: 7b64d67b6f217f9667fb674540c4829d622f463d
 
   # from tdx: https://git.toradex.com/cgit/toradex-manifest.git/tree/bsp/pinned-nxp.xml?h=5.7.0
   src/meta-freescale-3rdparty.git:


### PR DESCRIPTION
- store the alsa state in /etc instead of /var which is a tmpfs and does not provide the state after reboot
- added state-daemon.conf to switch on the alsa-state service which stores the state continuously
- added asound.conf for io4edge audio
- changed alsa.conf that alias names are also listed along with the sound devices